### PR TITLE
Iframe enable

### DIFF
--- a/js/viewer-ui.js
+++ b/js/viewer-ui.js
@@ -7,7 +7,7 @@
 var enableEmbedded = false;
 if (window.self !== window.top) {
   var $iframe_parent_div = window.frameElement ? $(window.frameElement.parentNode) : null;
-  if (!iframe_parent_div || !$iframe_parent_div.is(':visible')) enableEmbedded = true;
+  if (!$iframe_parent_div || !$iframe_parent_div.is(':visible')) enableEmbedded = true;
 }
 
 //[ "Forward Scatter (FSC-HLin)", "Side Scatter (SSC-HLin)",

--- a/js/viewer-ui.js
+++ b/js/viewer-ui.js
@@ -6,7 +6,8 @@
 
 var enableEmbedded = false;
 if (window.self !== window.top) {
-    enableEmbedded = true;
+  var $iframe_parent_div = window.frameElement ? $(window.frameElement.parentNode) : null;
+  if (!iframe_parent_div || !$iframe_parent_div.is(':visible')) enableEmbedded = true;
 }
 
 //[ "Forward Scatter (FSC-HLin)", "Side Scatter (SSC-HLin)",


### PR DESCRIPTION
Fixed issue https://github.com/informatics-isi-edu/chaise/issues/623. This was happening because now references in record-2 app are by default expanded instead of collapsed.

The code assumed that iframes are hidden by default and on their/parent resize, the content inside them is rendered/plotted.

Now we explicitly check whether the parent div of the iframe is visible or not to make the decision instead of depending on the collapse behaviour.
